### PR TITLE
Add 500kHz channel to US915 example configuration

### DIFF
--- a/content/guides/debian-ubuntu.md
+++ b/content/guides/debian-ubuntu.md
@@ -220,7 +220,7 @@ net_id="000000"
   max_dr=5
 {{< /highlight >}}
 
-### US915 configuration example (channels 0 - 7)
+### US915 configuration example sub-band 1 (125kHz channels 0 - 7 & 500kHz channel 64)
 
 {{<highlight toml>}}
 [general]
@@ -236,10 +236,10 @@ net_id="000000"
 name="US_902_928"
 
 [network_server.network_settings]
-enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7]
+enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7, 64]
 {{< /highlight >}}
 
-### US915 configuration example (channels 8 - 15)
+### US915 configuration example sub-band 2 (125kHz channels 8 - 15 & 500kHz channel 65)
 
 This is the same channel-plan as used by The Things Network.
 
@@ -257,7 +257,7 @@ net_id="000000"
 name="US_902_928"
 
 [network_server.network_settings]
-enabled_uplink_channels=[8, 9, 10, 11, 12, 13, 14, 15]
+enabled_uplink_channels=[8, 9, 10, 11, 12, 13, 14, 15, 65]
 {{< /highlight >}}
 
 ## Installing ChirpStack Application Server

--- a/content/guides/google-cloud-platform.md
+++ b/content/guides/google-cloud-platform.md
@@ -458,7 +458,7 @@ net_id="000000"
 timezone="Local"
 {{< /highlight>}}
 
-##### US915 configuration example
+##### US915 configuration example sub-band 1 (125kHz channels 0 - 7 & 500kHz channel 64)
 
 {{<highlight toml>}}
 [postgresql]
@@ -475,7 +475,7 @@ net_id="000000"
 
   [network_server.network_settings]
   rx1_delay=3
-  enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7]
+  enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7, 64]
 
   [network_server.gateway.backend]
   type="gcp_pub_sub"

--- a/content/guides/microsoft-azure.md
+++ b/content/guides/microsoft-azure.md
@@ -485,7 +485,7 @@ net_id="000000"
     commands_connection_string="[Gateway Commands Connection String]"
 {{</highlight>}}
 
-##### US915 example (channels 0 - 7)
+##### US915 example sub-band 1 (125kHz channels 0 - 7 & 500kHz channel 64)
 
 {{<highlight toml>}}
 [postgresql]
@@ -501,7 +501,7 @@ net_id="000000"
   name="US_902_928"
 
   [network_server.network_settings]
-  enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7]
+  enabled_uplink_channels=[0, 1, 2, 3, 4, 5, 6, 7, 64]
 
   [network_server.gateway.backend]
   type="azure_iot_hub"
@@ -511,7 +511,7 @@ net_id="000000"
     commands_connection_string="[Gateway Commands Connection String]"
 {{</highlight>}}
 
-##### US915 example (channels 8 - 15)
+##### US915 example sub-band 2 (125kHz channels 8 - 15 & 500kHz channel 65)
 
 {{<highlight toml>}}
 [postgresql]
@@ -527,7 +527,7 @@ net_id="000000"
   name="US_902_928"
 
   [network_server.network_settings]
-  enabled_uplink_channels=[8, 9, 10, 11, 12, 13, 14, 15]
+  enabled_uplink_channels=[8, 9, 10, 11, 12, 13, 14, 15, 65]
 
   [network_server.gateway.backend]
   type="azure_iot_hub"


### PR DESCRIPTION
US915 channels 64-72 are 500kHz uplink channels that should be enabled for the relevant subbands