### PR TITLE
Added Postgres integration activation instructions

### DIFF
--- a/docs/application-server/integrations/postgresql.md
+++ b/docs/application-server/integrations/postgresql.md
@@ -225,3 +225,40 @@ create index idx_device_location_dev_eui on device_location(dev_eui);
 create index idx_device_location_application_id on device_location(application_id);
 create index idx_device_location_tags on device_location(tags);
 ```
+
+## Activating the Integration
+
+In order for ChirpStack to start writing event data to a Postgres database, the integration must be explicitly enabled and configured in the `chirpstack-application-server.toml` configuration file.
+
+### Enabling the Integration 
+
+Run `sudo nano /etc/chirpstack-application-server/chirpstack-application-server.toml` to open it in an editor.
+
+In the file, find this section:
+```toml
+[application_server.integration]
+  # Enabled integrations.
+  enabled=["mqtt"]
+```
+Your `enabled` line may look slightly different, as you may have other integrations already active. Add `"postgresql"` to the array. In this case, the modified line should appear as `enabled=["mqtt", "postgresql"]`.
+
+### Configuring the Integration
+
+You must also set the configuration settings for the integration. If your configuration file does not already contain the following section, add it now:
+```toml
+  # PostgreSQL database integration.
+  [application_server.integration.postgresql]
+  # PostgreSQL dsn (e.g.: postgres://user:password@hostname/database?sslmode=disable).
+  dsn="postgres://<username>:<password>@<host>/<database>?sslmode=disable"
+  
+  # This sets the max. number of open connections that are allowed in the
+  # PostgreSQL connection pool (0 = unlimited).
+  max_open_connections=0
+
+  # Max idle connections.
+  #
+  # This sets the max. number of idle connections in the PostgreSQL connection
+  # pool (0 = no idle connections are retained).
+  max_idle_connections=2
+```
+In the `dns=` line, modify `<username>`, `<password>`, `<host>`, and `<database>` with your appropriate credentials and targets. If you followed the example above, you would use `chirpstack_as_events` as your username and target database. If your target Postgres database is on the same machine as the Application Server, use `localhost` as your host.


### PR DESCRIPTION
Once you know there's an integration enabling section in the chirpstack-application-server.toml configuration file, it's obvious, but if you're coming at this as a beginner, it takes way too much digging to discover that. Hopefully this will help clarify the exact steps needed to get the Postgres integration functioning.