### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ mkdocs-markdownextradata-plugin==0.1.7
 mkdocs-macros-plugin==0.4.9
 mkdocs-awesome-pages-plugin==2.2.1
 mkdocs-minify-plugin==0.3.0
+jinja2==3.0.3


### PR DESCRIPTION
New versions:
AttributeError: module 'jinja2' has no attribute 'contextfilter' So, to special version of mkdocs, we need jinja2=3.0.3 https://forums.docker.com/t/jinja-mkdocs-issue-breaks-docker101tutorial/122671